### PR TITLE
Fix tsc error from different casing in import and filename

### DIFF
--- a/server/src/features/auth/AuthMiddleware.ts
+++ b/server/src/features/auth/AuthMiddleware.ts
@@ -4,7 +4,7 @@ import { MaybeAsync } from 'purify-ts/MaybeAsync'
 import {
   getAccessTokenFromRequest,
   verifyAccessToken
-} from '../../infrastructure/JWT'
+} from '../../infrastructure/Jwt'
 import { findUserByUsername } from './UserRepo'
 
 export const optionalUser = (

--- a/server/src/features/auth/AuthRouter.ts
+++ b/server/src/features/auth/AuthRouter.ts
@@ -7,7 +7,7 @@ import {
   generateAccessToken,
   generateRefreshToken,
   verifyRefreshToken
-} from '../../infrastructure/JWT'
+} from '../../infrastructure/Jwt'
 import ms from 'ms'
 
 const setRefreshToken = (res: Response, token: string) => {

--- a/server/src/features/auth/LoginService.ts
+++ b/server/src/features/auth/LoginService.ts
@@ -5,7 +5,7 @@ import { Env } from '../../infrastructure/Env'
 import {
   generateAccessToken,
   generateRefreshToken
-} from '../../infrastructure/JWT'
+} from '../../infrastructure/Jwt'
 import { comparePasswords } from '../../infrastructure/Bcrypt'
 import { Left, Right } from 'purify-ts/Either'
 import { CustomError } from 'ts-custom-error'


### PR DESCRIPTION
```
$ npm run compile
> ts-fullstack-starter@1.0.0 compile /Users/raine/git/ts-react-express-starter/server
> tsc --noEmit

src/features/auth/AuthMiddleware.ts:7:8 - error TS1261: Already included file name 'server/src/infrastructure/JWT.ts' differs from file name 'server/src/infrastructure/Jwt.ts' only in casing.
  The file is in the program because:
    Imported via '../../infrastructure/JWT' from file 'server/src/features/auth/AuthMiddleware.ts'
    Imported via '../../infrastructure/JWT' from file 'server/src/features/auth/LoginService.ts'
    Imported via '../../infrastructure/JWT' from file 'server/src/features/auth/AuthRouter.ts'
    Matched by include pattern '**/*' in 'server/tsconfig.json'
```